### PR TITLE
Changed GroupKey file type from int to string

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ type (
 	// HookMessage is the message we receive from Alertmanager
 	HookMessage struct {
 		Version           string            `json:"version"`
-		GroupKey          int               `json:"groupKey"`
+		GroupKey          string            `json:"groupKey"`
 		Status            string            `json:"status"`
 		Receiver          string            `json:"receiver"`
 		GroupLabels       map[string]string `json:"groupLabels"`


### PR DESCRIPTION
Changed GroupKey file type from int to string into HookMessage struct. With int when an alert was received an error was generated
"2018/04/23 12:11:39 error decoding message: json: cannot unmarshal string into Go struct field HookMessage.groupKey of type int"
Changed type to string it started to work fine.
Prometheus version is 2.1